### PR TITLE
Add talks table

### DIFF
--- a/psconfeu2023.tests.ps1
+++ b/psconfeu2023.tests.ps1
@@ -5,7 +5,7 @@ Describe 'Running PSConfEU 2023 Tests' {
         It 'Should have some content' {
             $true | Should -be $true
         }
-        
+
         It 'Sponsors have some content' {
             $true | Should -be $true
         }
@@ -16,7 +16,7 @@ Describe 'Running PSConfEU 2023 Tests' {
             Start-Sleep -Seconds 2
             $true | Should -be $true
         }
-        
+
         It 'Should have coffee breaks ready' {
             $true | Should -be $true
         }
@@ -29,10 +29,60 @@ Describe 'Running PSConfEU 2023 Tests' {
             Start-Sleep -Seconds 2
             $true | Should -be $true
         }
-        
+
         It 'Sponsors have some content' {
             Start-Sleep -Seconds 1
             $true | Should -be $true
+        }
+    }
+
+    $agenda = @(
+        @{
+            Day = "Monday"
+            Sessions = @(
+                @{
+                    Time = "9:00"
+                    Titles = @(
+                        "Keynote"
+                    )
+                }
+                @{
+                    Time = "11:00"
+                    Titles = @(
+                        "Pester is the best"
+                        "Talk2"
+                    )
+                }
+            )
+        },
+        @{
+            Day = "Tuesday"
+            Sessions = @(
+                @{ 
+                    Time = "9:00"
+                    Titles = @(
+                        "talk 1"
+                        "Talk 2"
+                    )
+                }
+                @{
+                    Time = "10:00"
+                    Titles = @(
+                        "talk 1"
+                        "talk 2"
+                    )
+                }
+            )
+        }
+    )
+
+    Describe "Adding sessions" {
+        Describe "<Day>" -ForEach $Agenda {
+            Context "<_.Time>" -ForEach $_.Sessions {
+                It "<_>" -ForEach $_.Titles {
+                    Start-Sleep -Milliseconds (Get-Random -Minimum 100 -Maximum 500)
+                }
+            }
         }
     }
 }

--- a/psconfeu2023.tests.ps1
+++ b/psconfeu2023.tests.ps1
@@ -77,9 +77,14 @@ Describe 'Running PSConfEU 2023 Tests' {
     )
 
     Describe "Adding sessions" {
-        Describe "<Day>" -ForEach $Agenda {
-            Context "<_.Time>" -ForEach $_.Sessions {
-                It "<_>" -ForEach $_.Titles {
+
+        $agenda = Get-PSConfEUSchedule -output object | Group-Object Day
+
+        Describe "<_.Name>" -ForEach @($agenda.GetEnumerator()) {
+            $times = @($_.Group | Group-Object StartTime)
+            Context "<_.Name>" -ForEach $times {
+                $sessions = @($_.Group | Foreach-Object { @( $_."A1 (Track 1)", $_."A2 (Track 2)", $_."A3 (Track 3)", $_."B (Track 4)" | Where-Object { -not [string]::IsNullOrWhitespace($_)} | ForEach-Object { $_ -replace "\n", " - "})})
+                It "<_>" -ForEach $Sessions {
                     Start-Sleep -Milliseconds (Get-Random -Minimum 100 -Maximum 500)
                 }
             }

--- a/psconfeu2023.tests.ps1
+++ b/psconfeu2023.tests.ps1
@@ -36,46 +36,6 @@ Describe 'Running PSConfEU 2023 Tests' {
         }
     }
 
-    $agenda = @(
-        @{
-            Day = "Monday"
-            Sessions = @(
-                @{
-                    Time = "9:00"
-                    Titles = @(
-                        "Keynote"
-                    )
-                }
-                @{
-                    Time = "11:00"
-                    Titles = @(
-                        "Pester is the best"
-                        "Talk2"
-                    )
-                }
-            )
-        },
-        @{
-            Day = "Tuesday"
-            Sessions = @(
-                @{ 
-                    Time = "9:00"
-                    Titles = @(
-                        "talk 1"
-                        "Talk 2"
-                    )
-                }
-                @{
-                    Time = "10:00"
-                    Titles = @(
-                        "talk 1"
-                        "talk 2"
-                    )
-                }
-            )
-        }
-    )
-
     Describe "Adding sessions" {
 
         $agenda = Get-PSConfEUSchedule -output object | Group-Object Day


### PR DESCRIPTION
Loads sessions from agenda and shows them per day, and slot as pester tests.
![image](https://github.com/SynEdgy/PSConfEUChecks/assets/5735905/d5994544-a6cf-4fb2-bbd6-f8f5b9222dae)